### PR TITLE
Add Kucoin source to ADA/EUR

### DIFF
--- a/config/config-gofer.hcl
+++ b/config/config-gofer.hcl
@@ -231,6 +231,7 @@ gofer {
       origin "coinbase" { query = "ADA/EUR" }
       origin "kraken" { query = "ADA/EUR" }
       origin "binance_simple" { query = "ADA/EUR" }
+      origin "kucoin_prices_simple" { query = "ADA/EUR" }
     }
   }
 


### PR DESCRIPTION
This is anticipated to improve reliability of the feed when calculating median by making it an odd number of sources.

```sh
./gofer data ADA/EUR -o trace
```

```text
Data point for ADA/EUR:
───reference(time:2024-07-24T13:38:23.607832Z, value:Pair=ADA/EUR, Price=0.386505, Volume24h=0)
   └──median(meta.min_values:3, time:2024-07-24T13:38:23.607832Z, value:Pair=ADA/EUR, Price=0.386505, Volume24h=0)
      ├──origin(meta.expiry_threshold:5m0s, meta.freshness_threshold:1m0s, meta.origin:bitstamp, meta.query:ADA/EUR, time:2024-07-24T13:40:02.360910628Z, value:Pair=ADA/EUR, Price=0.38692, Volume24h=363772.7187)
      ├──origin(meta.expiry_threshold:5m0s, meta.freshness_threshold:1m0s, meta.origin:coinbase, meta.query:ADA/EUR, time:2024-07-24T13:38:23.607832Z, value:Pair=ADA/EUR, Price=0.3862, Volume24h=933034.38)
      ├──origin(meta.expiry_threshold:5m0s, meta.freshness_threshold:1m0s, meta.origin:kraken, meta.query:ADA/EUR, time:2024-07-24T13:40:02Z, value:Pair=ADA/EUR, Price=0.386505, Volume24h=604433.657)
      ├──origin(meta.expiry_threshold:5m0s, meta.freshness_threshold:1m0s, meta.origin:binance_simple, meta.query:ADA/EUR, time:2024-07-24T13:40:01Z, value:Pair=ADA/EUR, Price=0.3867, Volume24h=735599.6)
      └──origin(meta.expiry_threshold:5m0s, meta.freshness_threshold:1m0s, meta.origin:kucoin_prices_simple, meta.query:ADA/EUR, time:2024-07-24T13:40:03Z, value:Pair=ADA/EUR, Price=0.3864659042, Volume24h=<nil>)
```